### PR TITLE
Add Method to Fetch JSON Data from External API

### DIFF
--- a/jsongo.py
+++ b/jsongo.py
@@ -1,50 +1,55 @@
 from datetime import datetime
+import urllib.error
+import urllib.request
 
 class JsonGo:
-    def __init__(self):        
-        self.json_data = []
-        self.__number_of_entry = 0
-        self.json_string = ""
-    
-    def __init__(self, path: str):
-        self.__number_of_entry = 0
-        self.json_string = ""
-        self.json_data = self.convertToDic(path=path)
-               
+    def __init__(self, path = None):        
+        
+        if path:
+            self.json_data = self.convertToDic(path=path)
+        else: 
+            self.json_data = []
+ 
     def length(self) -> int:
-        return self.__number_of_entry
+        return len(self.json_data)
     
-    def convertToDic(self, path: str) -> list:
+    def convertToDic(self, path = None, json_string = None) -> list:
         
         """
         Converts a JSON file into a list of dictionaries.
 
         Args:
             path (str): The path to the JSON file.
+            json_string (str): JSON formated string value 
 
         Returns:
             list: A list of dictionaries, where each dictionary represents a JSON object from the file.
 
         Raises:
             Exception: If the file does not contain valid JSON.
+            Exception: If the given string does not contain valid JSON.
         """
-        try:
-            with open(path, 'rb') as file:
-                byte_code = file.read()
-                json_file = byte_code.decode('utf-8')
-        except Exception as e:
-            print(f"An error occured while converting: {e}")
+        if path:   
+            try:
+                with open(path, 'rb') as file:
+                    byte_code = file.read()
+                    json_file = byte_code.decode('utf-8')
+            except Exception as e:
+                raise Exception(f"An error occured while converting: {e}")
+        elif json_string:
+            json_file = json_string
+        else:
+            raise Exception("No path or string given!")
         
-        self.json_string = json_file
-        
-        self.JSON_Validator_self()
+        # Call JSON validator function
+        self.JSON_Validator(json_string=json_file)
         
         json_object = []
         
+        # Remove '[' and ']' from the JSON string if they exist
+        inside_array = json_file.strip()
         if json_file.startswith("["):
             inside_array = json_file.strip()[1:-1].strip()
-        else:
-            inside_array = json_file.strip()
         
         current_object = ''
         open_braces = 0
@@ -84,83 +89,10 @@ class JsonGo:
                     result[key] = list_of_values
                 else:    
                     result[key] = value
-                self.__number_of_entry += 1
             python_dicts.append(result)
         
-        return python_dicts
-    
-    def convertStringToDic(self, json: str) -> list:
-
-        """
-        Converts a JSON string into a list of dictionaries.
-
-        Args:
-            json (str): The JSON string to be converted.
-
-        Returns:
-            list: A list of dictionaries, where each dictionary represents a JSON object from the string.
-
-        Raises:
-            Exception: If the string does not contain valid JSON.
-            Exception: If the given string is empty.
-        """
-        if not json:
-            raise Exception("String is empty!")
-        
-        self.JSON_Validator_string(json)
-        
-        json_data = json
-        json_object = []
-        
-        if json_data.startswith("["):
-            inside_array = json_data.strip()[1:-1].strip()
-        else:
-            inside_array = json_data.strip()
-        
-        current_object = ''
-        open_braces = 0
-        
-        for char in inside_array:
-            if char == '{':
-                open_braces += 1
-            elif char == '}':
-                open_braces -= 1
-            
-            current_object += char
-            
-            if open_braces == 0 and current_object.strip():
-                json_object.append(current_object.strip())
-                current_object = ''
-
-        cleaned_objects = []
-        open_braces = 0
-                
-        cleaned_objects = [obj for obj in json_object if obj != ","]
-        
-        python_dicts = []
-        
-        for obj in cleaned_objects:
-            result = {}
-            json_str = obj.strip('{} ')
-            entries = json_str.split(',\n')
-            for entry in entries:
-                key, value = entry.split(':')
-                key = key.strip().strip('"')
-                value = value.strip().strip('"')
-                if "[" in value:
-                    value = value.strip('[]').strip()
-                    list_of_values = value.split(",")
-                    for i in range(len(list_of_values)):
-                        list_of_values[i] = list_of_values[i].strip().strip('"')
-                    result[key] = list_of_values
-                else:    
-                    result[key] = value
-                self.__number_of_entry += 1
-            python_dicts.append(result)
-        
-        return python_dicts
-    
-    def convertToJson(self, dic=None, path=""):
+        return python_dicts   
+    def convertToJson(self, dic=None, path=None):
         """
         Converts a given dictionary or the dictionaries stored in the object itself to a JSON string and writes it to a file.
 
@@ -174,7 +106,7 @@ class JsonGo:
         if not path:
             now = datetime.now()
             date_timer_str = now.strftime("%Y-%m-%d_%H-%M-%S")
-            path = date_timer_str + "_json.json" 
+            path = date_timer_str + "_json.json"
 
         if dic:
             string = self.toString(dic=dic)
@@ -192,6 +124,21 @@ class JsonGo:
 
         raise Exception("Wrong usage!")
     
+    def getAPI(self, url: str) -> str:
+        
+        if not url:
+            raise Exception("No URL given!")
+        
+        try:
+            with urllib.request.urlopen(url) as response:
+                raw_data = response.read().decode('utf-8')
+                self.JSON_Validator(json_string=raw_data)
+                return raw_data
+        except urllib.error.HTTPError as e:
+            raise Exception(f"HTTP error: code: {e.code} reason: {e.reason}")
+        except urllib.error.URLError as e:
+            raise Exception(f"URL error: reason: {e.reason}")
+    
     def __str__(self) -> str:
         if self.json_data:
             string = "["
@@ -206,7 +153,7 @@ class JsonGo:
             return string
         return ""
 
-    def toString(self, dic) -> str:
+    def toString(self, dic = None) -> str:
         if dic:
             string = "["
             for entry in self.json_data:
@@ -218,6 +165,8 @@ class JsonGo:
             string = string[:-1]
             string += "\n]"
             return string
+        elif self.json_data:
+            self.head(number=len(self.json_data)-1)
         return ""
         
     def head(self, number=5) -> str:
@@ -263,15 +212,15 @@ class JsonGo:
             if isinstance(json, dict):
                 self.json_data.append(json)
             elif isinstance(json, str):
-                self.JSON_Validator_string(json)
-                converted_string = self.convertStringToDic(json)
+                self.JSON_Validator(json_string=json)
+                converted_string = self.convertToDic(json_string=json)
                 self.json_data.extend(converted_string)
             else:
                 raise Exception("Only dictionary or string accepted!")
         else:
             raise Exception(f"{json} is empty!")
         
-    def JSON_Validator_Path(self, path: str):
+    def JSON_Validator(self, path = None, json_string = None):
         
         """
         Validates a JSON file against the standard JSON format.
@@ -282,80 +231,17 @@ class JsonGo:
         Raises:
             Exception: If the file does not exist or the JSON is not valid.
         """
-        if not path:
-            raise Exception("No path given!")
-        
-        try:
-            with open(path, 'rb') as file:
-                byte_code = file.read()
-                json_file = byte_code.decode('utf-8')
-        except Exception as e:
-            e.add_note("File not found!")
-        
-        if json_file.count('[') != json_file.count(']'):
-            raise Exception("The number of '[' does not equal with the number of ']'!")
-        
-        if json_file.count('{') != json_file.count('}'):
-            raise Exception("The number of '{' does not equal with the number of '}'!")
-        
-        if json_file.count('"') % 2 != 0:
-            raise Exception("Not valid JSON format!")
-        
-        for i, char in enumerate(json_file):
-            if char == ':':
-                if i - 2 <= 0:
-                    raise Exception("Not valid JSON format!")
-                if json_file[i - 1] not in ' "':
-                    raise Exception("Not valid JSON format!")
-                elif json_file[i - 1] in ' ' and json_file[i - 2] not in '"':
-                    raise Exception("Not valid JSON format!")
-        return True    
-    
-    def JSON_Validator_self(self):
-        """
-        Validates the JSON string stored in the object against the standard JSON format.
-
-        Raises:
-            Exception: If the JSON is not valid.
-        """
-        if not self.json_string:
-            return True
-        
-        json_file = self.json_string
-        
-        if json_file.count('[') != json_file.count(']'):
-            raise Exception("The number of '[' does not equal with the number of ']'!")
-        
-        if json_file.count('{') != json_file.count('}'):
-            raise Exception("The number of '{' does not equal with the number of '}'!")
-        
-        if json_file.count('"') % 2 != 0:
-            raise Exception("Not valid JSON format!")
-        
-        for i, char in enumerate(json_file):
-            if char == ':':
-                if i - 2 <= 0:
-                    raise Exception("Not valid JSON format!")
-                if json_file[i - 1] not in ' "':
-                    raise Exception("Not valid JSON format!")
-                elif json_file[i - 1] in ' ' and json_file[i - 2] not in '"':
-                    raise Exception("Not valid JSON format!")
-        return True
-    
-    def JSON_Validator_string(self, string):
-        """
-        Validates a given JSON string against the standard JSON format.
-
-        Args:
-            string (str): The JSON string to be validated.
-
-        Raises:
-            Exception: If the JSON is not valid.
-        """
-        if not string:
-            raise Exception("Empty string!")
-        
-        json_file = string
+        if path:
+            try:
+                with open(path, 'rb') as file:
+                    byte_code = file.read()
+                    json_file = byte_code.decode('utf-8')
+            except Exception as e:
+                e.add_note("File not found!")
+        elif json_string:
+            json_file = json_string
+        else:
+            json_file = self.toString(dic=self.json_data)
         
         if json_file.count('[') != json_file.count(']'):
             raise Exception("The number of '[' does not equal with the number of ']'!")

--- a/test.py
+++ b/test.py
@@ -1,11 +1,10 @@
-from jsoncompiler import JsonGo
+from jsongo import JsonGo
 
-testcase = JsonGo(path="jsongo\json2.json")
-string = """{
-    "value1" : 123
-}
-"""
-testcase.add(string)
-print(testcase.head())
-testcase.convertToJson()
+testcase = JsonGo()
 
+path = "https://dummyapi.online/api/todos"
+json_string = testcase.getAPI(path)
+
+
+json_data = testcase.convertToDic(json_string=json_string)
+print(json_data.head())


### PR DESCRIPTION
**Title:** Add Method to Fetch JSON Data from External API

**Description:**

- Implemented the `getAPI` method to retrieve JSON data from a specified URL.
- Utilizes `urllib.request` to open a connection and fetch data, ensuring compatibility with standard Python libraries.
- Includes robust error handling for both HTTP and URL errors, providing informative exceptions with error codes and reasons.
- Integrates JSON validation using the existing `JSON_Validator` method to ensure the fetched data is in a valid JSON format before processing.
- Returns the raw JSON string for further manipulation or storage within the `JsonGo` class.

This enhancement allows users to dynamically fetch and validate JSON data from external sources, expanding the functionality of the `JsonGo` class in web-based applications.